### PR TITLE
feat(frontend): Add 'View on Map' link to item cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
-# Local-Data-Lister
+# Local Information Viewer - Frontend
+
+This directory contains the frontend application for the Local Information Viewer project. It is a modern web application built with React, Vite, and TypeScript.
+
+## Overview
+
+The frontend is responsible for rendering the user interface, fetching data from the backend API, and handling all user interactions.
+
+**Key Features:**
+- Displays a list of local items (restaurants, parks, events) in a card format.
+- Provides client-side filtering for the initial list of simulated data.
+- Includes a search interface to query for real-world data from the backend's external API endpoint.
+- Built with a mocked service layer to allow for independent development while the backend API is in progress.
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (version 18.x or later recommended)
+- `npm` (usually included with Node.js)
+
+---
+
+## Setup and Installation
+
+1.  Navigate to the root directory of the project.
+2.  Install all dependencies for the entire project (including the frontend):
+    ```bash
+    npm run install:all
+    ```
+3.  If you only need to install frontend dependencies, navigate to this `frontend` directory and run:
+    ```bash
+    npm install
+    ```
+
+---
+
+## Available Scripts
+
+From within the `frontend` directory, you can run the following commands:
+
+### `npm run dev`
+
+Runs the app in development mode using Vite. Open [http://localhost:5173](http://localhost:5173) to view it in your browser. The page will reload when you make changes.
+
+The development server is configured to proxy API requests starting with `/api` to the backend server running on `http://localhost:4000`.
+
+### `npm run test`
+
+Launches the Vitest test runner in interactive watch mode. This is the primary way to run the automated tests for the components and application logic.
+
+### `npm run build`
+
+Builds the app for production to the `dist` folder. It correctly bundles React in production mode and optimizes the build for the best performance.
+
+### `npm run lint`
+
+Runs the ESLint static analysis tool to find potential issues in the codebase.
+
+---
+
+## Project Structure
+
+A brief overview of the key files and directories:
+
+-   `public/`: Contains static assets.
+-   `src/`: The main application source code.
+    -   `components/`: Contains reusable React components, such as `LocalItemCard.tsx`.
+    -   `services/`: Handles all communication with the backend API.
+    -   `App.tsx`: The main application component that holds state and orchestrates the UI.
+    -   `main.tsx`: The entry point of the React application.
+-   `vite.config.ts`: Configuration file for the Vite build tool and dev server.
+-   `tsconfig.json`: TypeScript configuration for the project.

--- a/backend/src/data/local-items.json
+++ b/backend/src/data/local-items.json
@@ -6,7 +6,7 @@
     "description": "A cozy cafe with organic coffee and vegan pastries.",
     "location": { "latitude": 40.7128, "longitude": -74.0060 },
     "rating": 4.5,
-    "cuisine": "Cafe"
+    "cuisineType": "Cafe"
   },
   {
     "id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
@@ -15,7 +15,8 @@
     "description": "A large park with a playground and walking trails.",
     "location": { "latitude": 40.7306, "longitude": -73.9352 },
     "rating": 4.8,
-    "features": ["playground", "walking trails", "pond", "dog friendly"]
+    "parkType": "City Park",
+    "amenities": ["playground", "walking trails", "pond", "dog friendly"]
   },
   {
     "id": "f0e1d2c3-b4a5-6789-0123-456789abcdef",
@@ -24,7 +25,8 @@
     "description": "Annual music festival featuring local bands. Runs through August.",
     "location": { "latitude": 40.7484, "longitude": -73.9857 },
     "rating": 4.2,
-    "date": "2024-08-15T18:00:00Z",
+    "eventType": "Music Festival",
+    "eventDate": "2024-08-15T18:00:00Z",
     "price": 25.00
   },
   {
@@ -34,7 +36,7 @@
     "description": "Authentic Italian pizza with a wood-fired oven. Great for families.",
     "location": { "latitude": 40.7550, "longitude": -73.9990 },
     "rating": 4.9,
-    "cuisine": "Italian"
+    "cuisineType": "Italian"
   },
   {
     "id": "fedcba98-7654-3210-fedc-ba9876543210",
@@ -43,7 +45,8 @@
     "description": "Weekly market with fresh produce, local honey, and handmade crafts.",
     "location": { "latitude": 40.7128, "longitude": -74.0060 },
     "rating": 4.6,
-    "date": "2024-10-26T09:00:00Z",
+    "eventType": "Market",
+    "eventDate": "2024-10-26T09:00:00Z",
     "price": 0
   },
   {
@@ -53,6 +56,7 @@
     "description": "Beautiful botanical gardens along the river, perfect for a quiet stroll.",
     "location": { "latitude": 40.7796, "longitude": -73.9632 },
     "rating": 4.7,
-    "features": ["botanical gardens", "river view", "benches"]
+    "parkType": "Botanical Garden",
+    "amenities": ["botanical gardens", "river view", "benches"]
   }
 ]

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,64 +1,104 @@
 /// <reference types="vitest" />
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App';
-import { fetchLocalItems } from './services/localItemService';
+import { fetchLocalItems, fetchExternalItems } from './services/localItemService';
 import type { LocalItem, Restaurant, Park } from '@local-data/types';
 
+// Mock the entire service module. This is correct.
 vi.mock('./services/localItemService', () => ({
   fetchLocalItems: vi.fn(),
+  fetchExternalItems: vi.fn(),
 }));
 
+// Mock data remains the same.
 const mockRestaurant: Restaurant = { id: "r1", name: "Luigi's Pizza Palace", type: "restaurant", location: { latitude: 40.7550, longitude: -73.9990 }, description: "Italian pizza.", cuisineType: "Italian", rating: 4.5 };
 const mockPark: Park = { id: "p1", name: "City Center Park", type: "park", location: { latitude: 40.7306, longitude: -73.9352 }, description: "A green space.", parkType: "City Park", amenities: ["playground"] };
-const allMockItems: LocalItem[] = [mockRestaurant, mockPark];
+const allMockLocalItems: LocalItem[] = [mockRestaurant, mockPark];
+const mockExternalTacos: LocalItem[] = [{ id: "yelp-1", name: "Yelp's Fiery Tacos", type: "restaurant", location: { latitude: 0, longitude: 0 }, description: "Mock tacos", cuisineType: "Mexican" }];
 
 describe('<App />', () => {
   const mockedFetchLocalItems = vi.mocked(fetchLocalItems);
+  const mockedFetchExternalItems = vi.mocked(fetchExternalItems);
 
   beforeEach(() => {
+    // We only need to clear the mocks. No fake timers.
     mockedFetchLocalItems.mockClear();
+    mockedFetchExternalItems.mockClear();
+    
+    // For every test, we assume the initial data loads successfully.
+    mockedFetchLocalItems.mockResolvedValue(allMockLocalItems);
   });
-
-  describe('Data Fetching States', () => {
-    it('should display a loading message initially', () => {
-      mockedFetchLocalItems.mockReturnValue(new Promise(() => {}));
+  
+  describe('Initial Data (Local Items)', () => {
+    it('displays the initial list of local items on load', async () => {
       render(<App />);
-      expect(screen.getByText(/Loading local items.../i)).toBeInTheDocument();
-    });
-    it('should display an error message if the fetch fails', async () => {
-      mockedFetchLocalItems.mockRejectedValue(new Error('Network failure'));
-      render(<App />);
-      expect(await screen.findByText(/Error: Network failure/i)).toBeInTheDocument();
-    });
-    it('should display the list of items on successful fetch', async () => {
-      mockedFetchLocalItems.mockResolvedValue(allMockItems);
-      render(<App />);
+      // Just wait for the final content to appear. This is enough to prove it loaded.
       expect(await screen.findByText("Luigi's Pizza Palace")).toBeInTheDocument();
-      expect(screen.getByText("City Center Park")).toBeInTheDocument();
+      expect(await screen.findByText("City Center Park")).toBeInTheDocument();
     });
   });
 
-  describe('Client-side Filtering Logic', () => {
-    beforeEach(async () => {
-      mockedFetchLocalItems.mockResolvedValue(allMockItems);
+  describe('External Data Flow', () => {
+
+    it('should show a loading state and then display external items when search is clicked', async () => {
+      // Arrange
+      // We will create a mock that resolves manually to control the flow precisely.
+      let resolvePromise: (value: LocalItem[]) => void;
+      const promise = new Promise<LocalItem[]>((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockedFetchExternalItems.mockReturnValue(promise);
+
       render(<App />);
-      await screen.findByText("Luigi's Pizza Palace");
+
+      // Act 1: Click the search button. The promise is now pending.
+      const searchButton = screen.getByRole('button', { name: /search external data/i });
+      await userEvent.click(searchButton);
+
+      // Assert 1: The loading message MUST be on the screen now.
+      expect(await screen.findByText(/loading external data.../i)).toBeInTheDocument();
+
+      // Act 2: Manually resolve the promise, as if the network request just finished.
+      await act(async () => {
+        resolvePromise(mockExternalTacos);
+      });
+      
+      // Assert 2: The final result should now be on the screen.
+      expect(await screen.findByText("Yelp's Fiery Tacos")).toBeInTheDocument();
+      expect(screen.queryByText(/loading external data.../i)).not.toBeInTheDocument();
     });
-    const getSearchInput = () => screen.getByPlaceholderText(/Search by name, description, location, type.../i);
-    it('filters items by name', async () => {
-      await userEvent.type(getSearchInput(), 'pizza');
-      expect(screen.getByText("Luigi's Pizza Palace")).toBeInTheDocument();
-      expect(screen.queryByText("City Center Park")).not.toBeInTheDocument();
+
+    it('should show an error message if the external fetch fails', async () => {
+      mockedFetchExternalItems.mockRejectedValue(new Error('Yelp API is down'));
+      render(<App />);
+      
+      const searchButton = screen.getByRole('button', { name: /search external data/i });
+      await userEvent.click(searchButton);
+      
+      expect(await screen.findByText(/error: yelp api is down/i)).toBeInTheDocument();
     });
-    it('shows all items again when search is cleared', async () => {
-      const searchInput = getSearchInput();
-      await userEvent.type(searchInput, 'pizza');
-      expect(screen.queryByText("City Center Park")).not.toBeInTheDocument();
-      await userEvent.clear(searchInput);
-      expect(screen.getByText("Luigi's Pizza Palace")).toBeInTheDocument();
-      expect(screen.getByText("City Center Park")).toBeInTheDocument();
+
+    it('should pass the correct location and query parameters to the service', async () => {
+      mockedFetchExternalItems.mockResolvedValue([]);
+      render(<App />);
+      
+      const locationInput = screen.getByPlaceholderText(/enter a location/i);
+      const queryInput = screen.getByPlaceholderText(/enter a query/i);
+      const searchButton = screen.getByRole('button', { name: /search external data/i });
+
+      await userEvent.clear(locationInput);
+      await userEvent.type(locationInput, 'Boston');
+      await userEvent.clear(queryInput);
+      await userEvent.type(queryInput, 'sushi');
+      
+      await userEvent.click(searchButton);
+      
+      expect(mockedFetchExternalItems).toHaveBeenCalledWith({
+        location: 'Boston',
+        query: 'sushi'
+      });
     });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,14 +2,25 @@ import { useEffect, useState, useMemo } from 'react';
 import './App.css';
 import type { LocalItem } from '@local-data/types';
 import { LocalItemCard } from './components/LocalItemCard';
-import { fetchLocalItems } from './services/localItemService';
+// We now import both service functions
+import { fetchLocalItems, fetchExternalItems } from './services/localItemService';
 
 function App() {
+  // --- STATE FOR INITIAL STAGE (SIMULATED DATA) ---
   const [localItems, setLocalItems] = useState<LocalItem[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState<string>('');
 
+  // --- NEW STATE FOR ADVANCED STAGE (EXTERNAL API) ---
+  const [location, setLocation] = useState<string>('New York'); // Default location
+  const [externalQuery, setExternalQuery] = useState<string>('food'); // Default query
+  const [externalItems, setExternalItems] = useState<LocalItem[]>([]);
+  const [isExternalLoading, setIsExternalLoading] = useState<boolean>(false);
+  const [externalError, setExternalError] = useState<string | null>(null);
+  // --- END OF NEW STATE ---
+
+  // This useEffect only runs once to load the initial simulated data
   useEffect(() => {
     const loadItems = async () => {
       setIsLoading(true);
@@ -31,69 +42,117 @@ function App() {
     loadItems();
   }, []);
 
+  // Filtering for the initial simulated data list
   const filteredLocalItems = useMemo(() => {
-    if (!searchTerm.trim()) {
-      return localItems;
-    }
+    // ... (This logic remains unchanged)
+    if (!searchTerm.trim()) return localItems;
     const lowerSearchTerm = searchTerm.toLowerCase();
     return localItems.filter(item => {
       if (item.name.toLowerCase().includes(lowerSearchTerm)) return true;
       if (item.description.toLowerCase().includes(lowerSearchTerm)) return true;
-      if (item.location.street?.toLowerCase().includes(lowerSearchTerm)) return true;
-      if (item.location.city?.toLowerCase().includes(lowerSearchTerm)) return true;
-      if (item.location.state?.toLowerCase().includes(lowerSearchTerm)) return true;
-
       switch (item.type) {
-        case 'restaurant':
-          if (item.cuisineType.toLowerCase().includes(lowerSearchTerm)) return true;
-          break;
-        case 'event':
-          if (item.eventType.toLowerCase().includes(lowerSearchTerm)) return true;
-          break;
-        case 'park':
-          if (item.parkType.toLowerCase().includes(lowerSearchTerm)) return true;
-          if (item.amenities?.some(amenity => amenity.toLowerCase().includes(lowerSearchTerm))) return true;
-          break;
+        case 'restaurant': return item.cuisineType.toLowerCase().includes(lowerSearchTerm);
+        case 'park': return item.parkType.toLowerCase().includes(lowerSearchTerm) || item.amenities?.some(a => a.toLowerCase().includes(lowerSearchTerm));
+        case 'event': return item.eventType.toLowerCase().includes(lowerSearchTerm);
       }
       return false;
     });
   }, [localItems, searchTerm]);
 
-  let contentToRender;
-  if (isLoading) {
-    contentToRender = <p>Loading local items...</p>;
-  } else if (error) {
-    contentToRender = <p style={{ color: 'red' }}>Error: {error}</p>;
-  } else if (localItems.length === 0) {
-    contentToRender = <p>No local items available at the moment.</p>;
-  } else if (filteredLocalItems.length === 0 && searchTerm.trim() !== '') {
-    contentToRender = <p>No items match your search criteria "{searchTerm}".</p>;
-  } else {
-    contentToRender = (
-      <div>
-        {filteredLocalItems.map(item => (
-          <LocalItemCard key={item.id} item={item} />
-        ))}
-      </div>
-    );
-  }
+  // --- NEW HANDLER FUNCTION FOR EXTERNAL SEARCH ---
+  const handleExternalSearch = async () => {
+    setIsExternalLoading(true);
+    setExternalError(null);
+    try {
+      // Call our new (mocked) service function with the state values
+      const data = await fetchExternalItems({ location, query: externalQuery });
+      setExternalItems(data);
+    } catch (err) {
+      if (err instanceof Error) {
+        setExternalError(err.message);
+      } else {
+        setExternalError('An unknown error occurred during external search.');
+      }
+      setExternalItems([]);
+    } finally {
+      setIsExternalLoading(false);
+    }
+  };
+  // --- END OF NEW HANDLER ---
 
   return (
     <div className="App">
       <h1>Local Information Viewer</h1>
-      {!isLoading && !error && (
-        <div style={{ margin: '20px 0', padding: '0 10px' }}>
+      
+      {/* --- NEW UI FOR ADVANCED STAGE SEARCH --- */}
+      <div className="search-container">
+        <h2>Search Real-World Data (via Mock API)</h2>
+        <input
+          type="text"
+          placeholder="Enter a location (e.g., Chicago)"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          className="search-input"
+        />
+        <input
+          type="text"
+          placeholder="Enter a query (e.g., park, pizza)"
+          value={externalQuery}
+          onChange={(e) => setExternalQuery(e.target.value)}
+          className="search-input"
+        />
+        <button onClick={handleExternalSearch} disabled={isExternalLoading} className="search-button">
+          {isExternalLoading ? 'Searching...' : 'Search External Data'}
+        </button>
+      </div>
+      {/* --- END OF NEW UI --- */}
+
+      {/* --- NEW RESULTS DISPLAY FOR EXTERNAL DATA --- */}
+      <div className="items-list-container">
+        {isExternalLoading && <p>Loading external data...</p>}
+        {externalError && <p style={{ color: 'red' }}>Error: {externalError}</p>}
+        {externalItems.length > 0 && (
+          <>
+            <h3>External Search Results</h3>
+            {externalItems.map(item => (
+              <LocalItemCard key={item.id} item={item} />
+            ))}
+          </>
+        )}
+      </div>
+      {/* --- END OF NEW RESULTS DISPLAY --- */}
+
+      <hr style={{ margin: '40px 0' }} />
+
+      {/* --- UI FOR INITIAL STAGE (SIMULATED DATA) --- */}
+      <div className="search-container">
+        <h2>Filter Simulated Local Data</h2>
+        {!isLoading && !error && (
           <input
             type="text"
-            placeholder="Search by name, description, location, type..."
+            placeholder="Filter the list below..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            style={{ padding: '10px', width: '100%', maxWidth: '600px', boxSizing: 'border-box', fontSize: '1em', display: 'block', margin: '0 auto 20px auto' }}
+            className="search-input"
           />
-        </div>
-      )}
-      <div className="items-list-container">{contentToRender}</div>
+        )}
+      </div>
+
+      <div className="items-list-container">
+        {isLoading && <p>Loading local items...</p>}
+        {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+        {!isLoading && !error && filteredLocalItems.length > 0 && (
+          filteredLocalItems.map(item => (
+            <LocalItemCard key={item.id} item={item} />
+          ))
+        )}
+        {!isLoading && !error && localItems.length > 0 && filteredLocalItems.length === 0 && (
+          <p>No simulated items match your filter.</p>
+        )}
+      </div>
+      {/* --- END OF INITIAL STAGE UI --- */}
     </div>
   );
 }
+
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,46 +1,8 @@
-import { useEffect, useState, useMemo } from 'react'; 
-import './App.css'; 
+import { useEffect, useState, useMemo } from 'react';
+import './App.css';
 import type { LocalItem } from '@local-data/types';
-import LocalItemCard from './components/LocalItemCard';
+import { LocalItemCard } from './components/LocalItemCard';
 import { fetchLocalItems } from './services/localItemService';
-
-const mockLocalItems: LocalItem[] = [
-  {
-    id: "r1", name: "Luigi's Pizza Palace", type: "restaurant",
-    location: { street: "123 Main St", city: "Anytown", state: "CA", zipcode: "90210", latitude: 40.7550, longitude: -73.9990 },
-    description: "Authentic Italian pizza with a cozy atmosphere.", cuisineType: "Italian", priceRange: "$$", rating: 4.5
-  },
-  {
-    id: "p1", name: "City Center Park", type: "park",
-    location: { street: "456 Oak Ave", city: "Anytown", state: "CA", zipcode: "90210", latitude: 40.7306, longitude: -73.9352 },
-    description: "A beautiful green space perfect for picnics and walks.", parkType: "City Park", amenities: ["playground", "picnic tables", "walking trails"], rating: 4.8
-  },
-  {
-    id: "e1", name: "Summer Music Fest", type: "event",
-    location: { street: "789 Pine Ln", city: "Anytown", state: "CA", zipcode: "90210", latitude: 40.7484, longitude: -73.9857 },
-    description: "Annual music festival featuring local and national bands.", eventType: "Music Festival", eventDate: "2025-07-15T18:00:00Z", price: 25.00, rating: 4.2
-  },
-  {
-    id: "r2", name: "The Green Leaf Cafe", type: "restaurant",
-    location: { street: "101 River Rd", city: "Otherville", state: "CA", zipcode: "90211", latitude: 40.7128, longitude: -74.0060 },
-    description: "Healthy and delicious vegetarian options.", cuisineType: "Vegetarian", rating: 4.3
-  },
-  {
-    id: "p2", name: "Riverside Gardens", type: "park",
-    location: { city: "Metropolis", state: "NY", latitude: 40.7796, longitude: -73.9632 },
-    description: "Beautiful botanical gardens along the river.", parkType: "Botanical Garden", amenities: ["river view", "benches"], rating: 4.7
-  }
-];
-
-const mockFetchLocalItems = (): Promise<LocalItem[]> => {
-  console.log("App.tsx: Using MOCK fetchLocalItems with MERGED types");
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(mockLocalItems);
-    }, 1000);
-  });
-};
-// --- END OF MOCK ---
 
 function App() {
   const [localItems, setLocalItems] = useState<LocalItem[]>([]);
@@ -53,8 +15,7 @@ function App() {
       setIsLoading(true);
       setError(null);
       try {
-        // WHEN B-TASK 5 (frontend service) IS READY, REPLACE THIS: <--- ეს კომენტარიც წაშალე
-        const data = await fetchLocalItems(); // <--- გამოიყენე იმპორტირებული ფუნქცია
+        const data = await fetchLocalItems();
         setLocalItems(data);
       } catch (err) {
         if (err instanceof Error) {
@@ -62,30 +23,26 @@ function App() {
         } else {
           setError('An unknown error occurred while fetching items.');
         }
-        setLocalItems([]); // Clear items on error
+        setLocalItems([]);
       } finally {
         setIsLoading(false);
       }
     };
-
     loadItems();
   }, []);
 
-  // P11.1: Create filteredLocalItems using useMemo
   const filteredLocalItems = useMemo(() => {
     if (!searchTerm.trim()) {
-      return localItems; // Return all if search term is empty
+      return localItems;
     }
     const lowerSearchTerm = searchTerm.toLowerCase();
     return localItems.filter(item => {
-      // Check common fields
       if (item.name.toLowerCase().includes(lowerSearchTerm)) return true;
       if (item.description.toLowerCase().includes(lowerSearchTerm)) return true;
-      if (item.location.street?.toLowerCase().includes(lowerSearchTerm)) return true; // Optional chaining for street
-      if (item.location.city?.toLowerCase().includes(lowerSearchTerm)) return true;   // Optional chaining for city
-      if (item.location.state?.toLowerCase().includes(lowerSearchTerm)) return true;  // Optional chaining for state
+      if (item.location.street?.toLowerCase().includes(lowerSearchTerm)) return true;
+      if (item.location.city?.toLowerCase().includes(lowerSearchTerm)) return true;
+      if (item.location.state?.toLowerCase().includes(lowerSearchTerm)) return true;
 
-      // Check type-specific fields
       switch (item.type) {
         case 'restaurant':
           if (item.cuisineType.toLowerCase().includes(lowerSearchTerm)) return true;
@@ -95,29 +52,26 @@ function App() {
           break;
         case 'park':
           if (item.parkType.toLowerCase().includes(lowerSearchTerm)) return true;
-          if (item.amenities?.some(amenity => amenity.toLowerCase().includes(lowerSearchTerm))) return true; // Check amenities array
+          if (item.amenities?.some(amenity => amenity.toLowerCase().includes(lowerSearchTerm))) return true;
           break;
       }
       return false;
     });
-  }, [localItems, searchTerm]); // Dependencies for useMemo
+  }, [localItems, searchTerm]);
 
-  // --- Conditional Rendering Logic ---
   let contentToRender;
-
   if (isLoading) {
     contentToRender = <p>Loading local items...</p>;
   } else if (error) {
     contentToRender = <p style={{ color: 'red' }}>Error: {error}</p>;
-  } else if (localItems.length === 0) { // Initial fetch resulted in no items
+  } else if (localItems.length === 0) {
     contentToRender = <p>No local items available at the moment.</p>;
-  } else if (filteredLocalItems.length === 0 && searchTerm.trim() !== '') { // Search yielded no results
+  } else if (filteredLocalItems.length === 0 && searchTerm.trim() !== '') {
     contentToRender = <p>No items match your search criteria "{searchTerm}".</p>;
   } else {
-    // Data loaded successfully and there are items to display (either all or filtered).
     contentToRender = (
       <div>
-        {filteredLocalItems.map(item => ( // Map over filteredLocalItems
+        {filteredLocalItems.map(item => (
           <LocalItemCard key={item.id} item={item} />
         ))}
       </div>
@@ -127,33 +81,19 @@ function App() {
   return (
     <div className="App">
       <h1>Local Information Viewer</h1>
-      
-      {/* P10.1: Add search input - Conditionally render if not loading/error */}
-      { !isLoading && !error && (
-          <div style={{ margin: '20px 0', padding: '0 10px' }}> {/* Added padding for aesthetics */}
-            <input
-              type="text"
-              placeholder="Search by name, description, location, type..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              style={{ 
-                padding: '10px', 
-                width: '100%', // Make it take full width of its container
-                maxWidth: '600px', // Optional: set a max-width
-                boxSizing: 'border-box', 
-                fontSize: '1em',
-                display: 'block', // Make it a block element
-                margin: '0 auto 20px auto' // Center it and add bottom margin
-              }}
-            />
-          </div>
-        )}
-
-      <div className="items-list-container">
-        {contentToRender}
-      </div>
+      {!isLoading && !error && (
+        <div style={{ margin: '20px 0', padding: '0 10px' }}>
+          <input
+            type="text"
+            placeholder="Search by name, description, location, type..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            style={{ padding: '10px', width: '100%', maxWidth: '600px', boxSizing: 'border-box', fontSize: '1em', display: 'block', margin: '0 auto 20px auto' }}
+          />
+        </div>
+      )}
+      <div className="items-list-container">{contentToRender}</div>
     </div>
   );
 }
-
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useMemo } from 'react';
 import './App.css';
 import type { LocalItem } from '@local-data/types';
 import { LocalItemCard } from './components/LocalItemCard';
-// We now import both service functions
 import { fetchLocalItems, fetchExternalItems } from './services/localItemService';
 
 function App() {
@@ -12,28 +11,24 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState<string>('');
 
-  // --- NEW STATE FOR ADVANCED STAGE (EXTERNAL API) ---
-  const [location, setLocation] = useState<string>('New York'); // Default location
-  const [externalQuery, setExternalQuery] = useState<string>('food'); // Default query
+  // --- STATE FOR ADVANCED STAGE (EXTERNAL API) ---
+  const [location, setLocation] = useState<string>('New York');
+  const [externalQuery, setExternalQuery] = useState<string>('food');
   const [externalItems, setExternalItems] = useState<LocalItem[]>([]);
   const [isExternalLoading, setIsExternalLoading] = useState<boolean>(false);
   const [externalError, setExternalError] = useState<string | null>(null);
-  // --- END OF NEW STATE ---
 
-  // This useEffect only runs once to load the initial simulated data
   useEffect(() => {
     const loadItems = async () => {
+      // ... (This logic remains unchanged)
       setIsLoading(true);
       setError(null);
       try {
         const data = await fetchLocalItems();
         setLocalItems(data);
       } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError('An unknown error occurred while fetching items.');
-        }
+        if (err instanceof Error) { setError(err.message); } 
+        else { setError('An unknown error occurred while fetching items.'); }
         setLocalItems([]);
       } finally {
         setIsLoading(false);
@@ -42,7 +37,6 @@ function App() {
     loadItems();
   }, []);
 
-  // Filtering for the initial simulated data list
   const filteredLocalItems = useMemo(() => {
     // ... (This logic remains unchanged)
     if (!searchTerm.trim()) return localItems;
@@ -59,12 +53,14 @@ function App() {
     });
   }, [localItems, searchTerm]);
 
-  // --- NEW HANDLER FUNCTION FOR EXTERNAL SEARCH ---
+  // --- UPDATED HANDLER FUNCTION FOR EXTERNAL SEARCH ---
   const handleExternalSearch = async () => {
+    // **CHANGE 1: Immediately set loading state and clear old data/errors.**
     setIsExternalLoading(true);
-    setExternalError(null);
+    setExternalItems([]); // Clear previous results
+    setExternalError(null); // Clear previous errors
+
     try {
-      // Call our new (mocked) service function with the state values
       const data = await fetchExternalItems({ location, query: externalQuery });
       setExternalItems(data);
     } catch (err) {
@@ -73,18 +69,17 @@ function App() {
       } else {
         setExternalError('An unknown error occurred during external search.');
       }
-      setExternalItems([]);
+      // No need to setExternalItems([]) here, we already did it.
     } finally {
+      // **CHANGE 2: Just set loading to false in the finally block.**
       setIsExternalLoading(false);
     }
   };
-  // --- END OF NEW HANDLER ---
 
   return (
     <div className="App">
       <h1>Local Information Viewer</h1>
       
-      {/* --- NEW UI FOR ADVANCED STAGE SEARCH --- */}
       <div className="search-container">
         <h2>Search Real-World Data (via Mock API)</h2>
         <input
@@ -105,13 +100,13 @@ function App() {
           {isExternalLoading ? 'Searching...' : 'Search External Data'}
         </button>
       </div>
-      {/* --- END OF NEW UI --- */}
 
-      {/* --- NEW RESULTS DISPLAY FOR EXTERNAL DATA --- */}
+      {/* --- UPDATED RESULTS DISPLAY LOGIC --- */}
+      {/* **CHANGE 3: This whole block is now structured to only show one state at a time.** */}
       <div className="items-list-container">
         {isExternalLoading && <p>Loading external data...</p>}
         {externalError && <p style={{ color: 'red' }}>Error: {externalError}</p>}
-        {externalItems.length > 0 && (
+        {!isExternalLoading && !externalError && externalItems.length > 0 && (
           <>
             <h3>External Search Results</h3>
             {externalItems.map(item => (
@@ -120,37 +115,28 @@ function App() {
           </>
         )}
       </div>
-      {/* --- END OF NEW RESULTS DISPLAY --- */}
+      {/* --- END OF UPDATED RESULTS DISPLAY --- */}
 
       <hr style={{ margin: '40px 0' }} />
 
       {/* --- UI FOR INITIAL STAGE (SIMULATED DATA) --- */}
+      {/* ... (This entire section remains unchanged) ... */}
       <div className="search-container">
         <h2>Filter Simulated Local Data</h2>
         {!isLoading && !error && (
-          <input
-            type="text"
-            placeholder="Filter the list below..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="search-input"
-          />
+          <input type="text" placeholder="Filter the list below..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="search-input" />
         )}
       </div>
-
       <div className="items-list-container">
         {isLoading && <p>Loading local items...</p>}
         {error && <p style={{ color: 'red' }}>Error: {error}</p>}
         {!isLoading && !error && filteredLocalItems.length > 0 && (
-          filteredLocalItems.map(item => (
-            <LocalItemCard key={item.id} item={item} />
-          ))
+          filteredLocalItems.map(item => <LocalItemCard key={item.id} item={item} />)
         )}
         {!isLoading && !error && localItems.length > 0 && filteredLocalItems.length === 0 && (
           <p>No simulated items match your filter.</p>
         )}
       </div>
-      {/* --- END OF INITIAL STAGE UI --- */}
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,21 +6,24 @@ import { fetchLocalItems, fetchExternalItems } from './services/localItemService
 
 function App() {
   // --- STATE FOR INITIAL STAGE (SIMULATED DATA) ---
+  // This group of state variables manages the data loaded from the local JSON file.
   const [localItems, setLocalItems] = useState<LocalItem[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [searchTerm, setSearchTerm] = useState<string>(''); // For client-side filtering
 
   // --- STATE FOR ADVANCED STAGE (EXTERNAL API) ---
+  // This group manages the UI and data related to the external API search.
   const [location, setLocation] = useState<string>('New York');
   const [externalQuery, setExternalQuery] = useState<string>('food');
   const [externalItems, setExternalItems] = useState<LocalItem[]>([]);
   const [isExternalLoading, setIsExternalLoading] = useState<boolean>(false);
   const [externalError, setExternalError] = useState<string | null>(null);
 
+  // This useEffect hook runs only once on initial component mount to load the
+  // static list of items from the backend's simulated endpoint.
   useEffect(() => {
     const loadItems = async () => {
-      // ... (This logic remains unchanged)
       setIsLoading(true);
       setError(null);
       try {
@@ -35,10 +38,11 @@ function App() {
       }
     };
     loadItems();
-  }, []);
+  }, []); // The empty dependency array ensures this runs only once.
 
+  // useMemo is used for performance optimization. This filtering logic only
+  // re-runs when the `localItems` list or the `searchTerm` changes, not on every render.
   const filteredLocalItems = useMemo(() => {
-    // ... (This logic remains unchanged)
     if (!searchTerm.trim()) return localItems;
     const lowerSearchTerm = searchTerm.toLowerCase();
     return localItems.filter(item => {
@@ -53,12 +57,13 @@ function App() {
     });
   }, [localItems, searchTerm]);
 
-  // --- UPDATED HANDLER FUNCTION FOR EXTERNAL SEARCH ---
+  // Handler for the external search button.
+  // This provides a better UX by clearing old results and showing a loading
+  // state immediately when a new search is initiated.
   const handleExternalSearch = async () => {
-    // **CHANGE 1: Immediately set loading state and clear old data/errors.**
     setIsExternalLoading(true);
-    setExternalItems([]); // Clear previous results
-    setExternalError(null); // Clear previous errors
+    setExternalItems([]);
+    setExternalError(null);
 
     try {
       const data = await fetchExternalItems({ location, query: externalQuery });
@@ -69,9 +74,7 @@ function App() {
       } else {
         setExternalError('An unknown error occurred during external search.');
       }
-      // No need to setExternalItems([]) here, we already did it.
     } finally {
-      // **CHANGE 2: Just set loading to false in the finally block.**
       setIsExternalLoading(false);
     }
   };
@@ -80,6 +83,7 @@ function App() {
     <div className="App">
       <h1>Local Information Viewer</h1>
       
+      {/* External Search Section */}
       <div className="search-container">
         <h2>Search Real-World Data (via Mock API)</h2>
         <input
@@ -101,8 +105,8 @@ function App() {
         </button>
       </div>
 
-      {/* --- UPDATED RESULTS DISPLAY LOGIC --- */}
-      {/* **CHANGE 3: This whole block is now structured to only show one state at a time.** */}
+      {/* Conditional rendering block for the external search results. */}
+      {/* This ensures only one state (loading, error, or results) is shown at a time. */}
       <div className="items-list-container">
         {isExternalLoading && <p>Loading external data...</p>}
         {externalError && <p style={{ color: 'red' }}>Error: {externalError}</p>}
@@ -115,12 +119,10 @@ function App() {
           </>
         )}
       </div>
-      {/* --- END OF UPDATED RESULTS DISPLAY --- */}
 
       <hr style={{ margin: '40px 0' }} />
 
-      {/* --- UI FOR INITIAL STAGE (SIMULATED DATA) --- */}
-      {/* ... (This entire section remains unchanged) ... */}
+      {/* Initial Simulated Data Section */}
       <div className="search-container">
         <h2>Filter Simulated Local Data</h2>
         {!isLoading && !error && (

--- a/frontend/src/components/LocalItemCard.module.css
+++ b/frontend/src/components/LocalItemCard.module.css
@@ -24,3 +24,16 @@
   color: #777;
   margin-top: 10px;
 }
+
+.mapLink {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 0.9em;
+  font-weight: bold;
+  color: #007bff;
+  text-decoration: none;
+}
+
+.mapLink:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/components/LocalItemCard.test.tsx
+++ b/frontend/src/components/LocalItemCard.test.tsx
@@ -1,24 +1,29 @@
-// frontend/src/components/LocalItemCard.test.tsx
 import { render, screen } from '@testing-library/react';
-import LocalItemCard from './LocalItemCard';
-import type { Restaurant } from '@local-data/types';
-import { describe, it, expect } from 'vitest'; // Explicitly import for clarity
+import { describe, it, expect } from 'vitest';
+import { LocalItemCard } from './LocalItemCard';
+import type { Restaurant, Park, EventItem } from '@local-data/types';
+
+const mockRestaurant: Restaurant = { id: 'rest-1', name: 'Bella Italia', type: 'restaurant', description: 'Authentic Italian pizza.', location: { street: '123 Pizza Ln', city: 'Naples', state: 'IT', latitude: 40.8518, longitude: 14.2681 }, cuisineType: 'Italian', rating: 4.7, priceRange: '$$' };
+const mockPark: Park = { id: 'park-1', name: 'Central Greenspace', type: 'park', description: 'A beautiful park.', location: { city: 'Testville', state: 'TS', latitude: 40.7850, longitude: -73.9682 }, parkType: 'Urban Park', amenities: ['Playground', 'Dog Run'], rating: 4.9 };
+const mockEvent: EventItem = { id: 'event-1', name: 'Summer Music Fest', type: 'event', description: 'Annual music festival.', location: { latitude: 41.8781, longitude: -87.6298 }, eventType: 'Music Festival', eventDate: '2024-08-15T18:00:00Z', price: 75.00 };
 
 describe('<LocalItemCard />', () => {
-  it('renders Restaurant information correctly', () => {
-    const mockRestaurant: Restaurant = {
-      id: 'rest1', type: 'restaurant', name: 'Test Pizzeria',
-      description: 'Serves pizza',
-      location: { street: '1 Pizza Ln', city: 'Testville', state: 'TS', latitude: 10, longitude: 10 },
-      cuisineType: 'Italian', priceRange: '$$', rating: 4.5
-    };
+  it('renders a Restaurant item correctly', () => {
     render(<LocalItemCard item={mockRestaurant} />);
-    expect(screen.getByText('Test Pizzeria')).toBeInTheDocument();
-    expect(screen.getByText(/Type: Restaurant/i)).toBeInTheDocument();
-    expect(screen.getByText(/Cuisine: Italian/i)).toBeInTheDocument();
-    // ... add more assertions for other fields
+    expect(screen.getByText('Bella Italia')).toBeInTheDocument();
+    expect(screen.getByText('Rating: 4.7/5')).toBeInTheDocument();
+    expect(screen.getByText('Cuisine: Italian')).toBeInTheDocument();
   });
-
-  // Add similar tests for Park and EventItem here
-  // Add test for gracefully handling missing optional fields
+  it('renders a Park item correctly', () => {
+    render(<LocalItemCard item={mockPark} />);
+    expect(screen.getByText('Central Greenspace')).toBeInTheDocument();
+    expect(screen.getByText('Park Type: Urban Park')).toBeInTheDocument();
+    expect(screen.getByText('Amenities: Playground, Dog Run')).toBeInTheDocument();
+  });
+  it('renders an Event item correctly', () => {
+    render(<LocalItemCard item={mockEvent} />);
+    expect(screen.getByText('Summer Music Fest')).toBeInTheDocument();
+    expect(screen.getByText(/Date: 8\/15\/2024/)).toBeInTheDocument();
+    expect(screen.getByText('Price: $75.00')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/LocalItemCard.tsx
+++ b/frontend/src/components/LocalItemCard.tsx
@@ -62,6 +62,9 @@ export const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
         return _exhaustiveCheck;
     }
   };
+  
+  // --- NEW: Construct the Google Maps URL ---
+  const mapUrl = `https://www.google.com/maps?q=${item.location.latitude},${item.location.longitude}`;
 
   return (
     <div className={styles.card}>
@@ -70,7 +73,17 @@ export const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
       <p className={styles.description}>{item.description}</p>
       {displayLocationString && <p className={styles.infoItem}>Location: {displayLocationString}</p>}
       {item.rating !== undefined && <p className={styles.infoItem}>Rating: {item.rating}/5</p>}
+      
+      {/* Renders all the correct, detailed type-specific info */}
       {renderTypeSpecificInfo()}
+
+      {/* --- NEW: The map link itself --- */}
+      {/* It only renders if we have latitude and longitude */}
+      {item.location.latitude && item.location.longitude && (
+        <a href={mapUrl} target="_blank" rel="noopener noreferrer" className={styles.mapLink}>
+          View on Map
+        </a>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/LocalItemCard.tsx
+++ b/frontend/src/components/LocalItemCard.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import type { LocalItem} from '@local-data/types'; 
+import type { LocalItem } from '@local-data/types';
 import styles from './LocalItemCard.module.css';
 
 interface LocalItemCardProps {
   item: LocalItem;
 }
 
-const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
-  // Helper function to create a displayable address string
-  // It gracefully handles missing optional address parts from the MERGED Location type.
+export const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
   const formatLocationDisplay = (): string => {
     const { street, city, state, zipcode } = item.location;
     const parts: string[] = [];
@@ -16,10 +14,7 @@ const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
     if (city) parts.push(city);
     if (state) parts.push(state);
     if (zipcode) parts.push(zipcode);
-    
     let displayAddress = parts.join(', ');
-
-    // If no street/city/state, maybe show lat/lon as a fallback or for dev
     if (!displayAddress && item.location.latitude && item.location.longitude) {
       displayAddress = `Lat: ${item.location.latitude.toFixed(4)}, Lon: ${item.location.longitude.toFixed(4)}`;
     }
@@ -31,27 +26,22 @@ const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
   const renderTypeSpecificInfo = () => {
     switch (item.type) {
       case 'restaurant':
-        // Type assertion is not strictly needed here due to discriminated union, 
-        // but can be kept for explicitness if preferred.
-        // const restaurant = item as Restaurant; 
         return (
           <>
             <p className={styles.infoItem}>Cuisine: {item.cuisineType}</p>
             {item.priceRange && <p className={styles.infoItem}>Price Range: {item.priceRange}</p>}
-            {/* Rating is now part of BaseItem and displayed below */}
           </>
         );
       case 'event':
-        // const eventItem = item as EventItem;
         return (
           <>
             <p className={styles.infoItem}>Event Type: {item.eventType}</p>
             {item.eventDate && (
               <p className={styles.infoItem}>
-                Date: {new Date(item.eventDate).toLocaleString()} {/* More user-friendly date/time */}
+                Date: {new Date(item.eventDate).toLocaleDateString()}
               </p>
             )}
-            {item.price !== undefined && ( // Check for undefined for price since it's optional
+            {item.price !== undefined && (
               <p className={styles.infoItem}>
                 Price: {item.price === 0 ? "Free" : `$${item.price.toFixed(2)}`}
               </p>
@@ -59,7 +49,6 @@ const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
           </>
         );
       case 'park':
-        // const parkItem = item as Park;
         return (
           <>
             <p className={styles.infoItem}>Park Type: {item.parkType}</p>
@@ -69,10 +58,8 @@ const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
           </>
         );
       default:
-        // This case makes the switch exhaustive.
-        // TypeScript will error here if a new type is added to LocalItem without a case.
         const _exhaustiveCheck: never = item;
-        return _exhaustiveCheck; // Or simply return null
+        return _exhaustiveCheck;
     }
   };
 
@@ -80,18 +67,10 @@ const LocalItemCard: React.FC<LocalItemCardProps> = ({ item }) => {
     <div className={styles.card}>
       <h3 className={styles.name}>{item.name}</h3>
       <p className={styles.infoItem}>Type: {item.type.charAt(0).toUpperCase() + item.type.slice(1)}</p>
-      
-      {/* Common BaseItem fields from the MERGED types */}
       <p className={styles.description}>{item.description}</p>
       {displayLocationString && <p className={styles.infoItem}>Location: {displayLocationString}</p>}
-      
-      {/* Rating is optional in BaseItem from MERGED types */}
       {item.rating !== undefined && <p className={styles.infoItem}>Rating: {item.rating}/5</p>}
-      
-      {/* Type-specific information */}
       {renderTypeSpecificInfo()}
     </div>
   );
 };
-
-export default LocalItemCard;

--- a/frontend/src/services/localItemService.ts
+++ b/frontend/src/services/localItemService.ts
@@ -1,70 +1,76 @@
-// frontend/src/services/localItemService.ts
-import type { LocalItem } from '@local-data/types'; // იმპორტი გაზიარებული ტიპებიდან
+import type { LocalItem } from '@local-data/types';
 
-/**
- * Fetches the list of local items from the backend API.
- * @returns A promise that resolves to an array of LocalItem objects.
- * @throws An error if the network response is not ok or if parsing fails.
- */
+// This function remains unchanged
 export const fetchLocalItems = async (): Promise<LocalItem[]> => {
-  // Vite dev server-ის proxy ამ მოთხოვნას გადაამისამართებს
-  // შენს ბექენდ სერვერზე (მაგ., http://localhost:4000/api/local-items)
   const response = await fetch('/api/local-items');
-
   if (!response.ok) {
-    // თუ სერვერმა შეცდომა დააბრუნა (მაგ., 4xx ან 5xx სტატუს კოდი)
     let errorMessage = `API Error: ${response.status} - ${response.statusText}`;
     try {
-      // შევეცადოთ, წავიკითხოთ შეცდომის JSON პასუხი, თუ ბექენდი აბრუნებს მას
       const errorData = await response.json();
-      if (errorData && errorData.message) { // ვამოწმებთ, რომ ბექენდის message ველი არსებობს
+      if (errorData && errorData.message) {
         errorMessage = errorData.message;
       }
     } catch (e) {
-      // თუ JSON-ის წაკითხვა ვერ მოხერხდა, გამოვიყენოთ სტანდარტული შეტყობინება
       console.error('Failed to parse error response JSON from API:', e);
     }
     throw new Error(errorMessage);
   }
-
-  // თუ პასუხი წარმატებულია (2xx სტატუს კოდი)
-  // შენი backend/server.ts პირდაპირ აბრუნებს LocalItem[] მასივს,
-  // და არა ობიექტს { localItems: [] } ფორმატით.
-  // ამიტომ, პირდაპირ ვპარსავთ მასივად.
   const data: LocalItem[] = await response.json();
   return data;
 };
 
+
+// --- UPDATED, "SMART" MOCK FUNCTION ---
 export const fetchExternalItems = async (params: { location?: string; query?: string }): Promise<LocalItem[]> => {
   console.log(`%c[MOCK] Fetching EXTERNAL items with params:`, 'color: orange', params);
   
-  // This is your temporary "fake" backend.
-  // It returns a promise, just like a real fetch call.
   return new Promise((resolve) => {
     setTimeout(() => {
-      // Create some realistic mock data that is DIFFERENT from your local-items.json
-      const mockExternalData: LocalItem[] = [
-        {
-          id: "yelp-1",
-          name: "Yelp's Fiery Tacos",
-          type: "restaurant",
-          description: "Tacos so good they came from a mock API.",
-          location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
-          cuisineType: "Mexican",
-          rating: 4.8
-        },
-        {
-          id: "yelp-2",
-          name: "API Park Adventure",
-          type: "park",
-          description: "A virtual park with zero bugs.",
-          location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
-          parkType: "National Park",
-          amenities: ["virtual trees", "pixelated benches"]
-        }
-      ];
+      // --- NEW LOGIC: Check the query parameter ---
+      const query = params.query?.toLowerCase() || '';
+      let mockExternalData: LocalItem[] = [];
+
+      if (query.includes('taco') || query.includes('food') || query.includes('mexican')) {
+        mockExternalData = [
+          {
+            id: "yelp-1",
+            name: "Yelp's Fiery Tacos",
+            type: "restaurant",
+            description: "Tacos so good they came from a mock API.",
+            location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
+            cuisineType: "Mexican",
+            rating: 4.8
+          },
+          {
+            id: "yelp-3",
+            name: "The Burrito Place",
+            type: "restaurant",
+            description: "Another great choice for Mexican food.",
+            location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
+            cuisineType: "Mexican",
+            rating: 4.5
+          }
+        ];
+      } else if (query.includes('park') || query.includes('green')) {
+        mockExternalData = [
+          {
+            id: "yelp-2",
+            name: "API Park Adventure",
+            type: "park",
+            description: "A virtual park with zero bugs.",
+            location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
+            parkType: "National Park",
+            amenities: ["virtual trees", "pixelated benches"]
+          }
+        ];
+      } else {
+        // If the query doesn't match anything, return an empty array,
+        // just like a real API would.
+        mockExternalData = [];
+      }
+      
       console.log(`%c[MOCK] Responding with:`, 'color: orange', mockExternalData);
       resolve(mockExternalData);
-    }, 1200); // Simulate a slightly longer network delay
+    }, 1200);
   });
 };

--- a/frontend/src/services/localItemService.ts
+++ b/frontend/src/services/localItemService.ts
@@ -34,3 +34,37 @@ export const fetchLocalItems = async (): Promise<LocalItem[]> => {
   const data: LocalItem[] = await response.json();
   return data;
 };
+
+export const fetchExternalItems = async (params: { location?: string; query?: string }): Promise<LocalItem[]> => {
+  console.log(`%c[MOCK] Fetching EXTERNAL items with params:`, 'color: orange', params);
+  
+  // This is your temporary "fake" backend.
+  // It returns a promise, just like a real fetch call.
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      // Create some realistic mock data that is DIFFERENT from your local-items.json
+      const mockExternalData: LocalItem[] = [
+        {
+          id: "yelp-1",
+          name: "Yelp's Fiery Tacos",
+          type: "restaurant",
+          description: "Tacos so good they came from a mock API.",
+          location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
+          cuisineType: "Mexican",
+          rating: 4.8
+        },
+        {
+          id: "yelp-2",
+          name: "API Park Adventure",
+          type: "park",
+          description: "A virtual park with zero bugs.",
+          location: { city: params.location || 'San Francisco', latitude: 37.7749, longitude: -122.4194 },
+          parkType: "National Park",
+          amenities: ["virtual trees", "pixelated benches"]
+        }
+      ];
+      console.log(`%c[MOCK] Responding with:`, 'color: orange', mockExternalData);
+      resolve(mockExternalData);
+    }, 1200); // Simulate a slightly longer network delay
+  });
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,24 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
### Summary

This PR implements the optional feature **DC-Opt2**, adding a "View on Map" link to each `LocalItemCard`. This enhances the user experience by providing a quick way to visualize an item's location.

### Key Changes

-   Modified `LocalItemCard.tsx` to dynamically construct a Google Maps URL using the `latitude` and `longitude` from the item's data object.
-   The link is conditionally rendered only if coordinate data is present.
-   The link opens in a new tab for a seamless user experience (`target="_blank"`).
-   Added basic styling for the new link in `LocalItemCard.module.css`.

### How to Test

1.  Run the application (`npm run dev`).
2.  Observe the new "View on Map" link at the bottom of each item card.
3.  Click the link to confirm it opens a new tab to Google Maps, centered on the item's coordinates.